### PR TITLE
Add endermen spawn to the Uplands

### DIFF
--- a/src/main/scala/robosky/uplands/world/biome/UplandsAutumnBiome.scala
+++ b/src/main/scala/robosky/uplands/world/biome/UplandsAutumnBiome.scala
@@ -2,6 +2,7 @@ package robosky.uplands.world.biome
 
 import net.fabricmc.api.{EnvType, Environment}
 import net.minecraft.block.{BlockState, Blocks}
+import net.minecraft.entity.{EntityCategory, EntityType}
 import net.minecraft.util.math.BlockPos
 import net.minecraft.world.biome.Biome
 import net.minecraft.world.biome.Biome.Category
@@ -71,6 +72,8 @@ object UplandsAutumnBiome
   addStructureFeature(MegadungeonFeature.configure(FeatureConfig.DEFAULT))
   addFeature(GenerationStep.Feature.UNDERGROUND_STRUCTURES, MegadungeonFeature.configure(FeatureConfig.DEFAULT)
     .createDecoratedFeature(Decorator.NOPE.configure(new NopeDecoratorConfig())))
+
+  addSpawn(EntityCategory.MONSTER, new Biome.SpawnEntry(EntityType.ENDERMAN, 10, 1, 4))
 
   @Environment(EnvType.CLIENT)
   override def getSkyColor = 12632319


### PR DESCRIPTION
Since endermen spawn in all three vanilla dimensions, this PR allows endermen to spawn in the Uplands as well. They spawn with the same weights as in the overworld, though you will see more because nothing else spawns currently.