### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/robosky/uplands/block/AzoteMushroomBlock.java
+++ b/src/main/java/robosky/uplands/block/AzoteMushroomBlock.java
@@ -9,6 +9,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
+import net.minecraft.world.WorldView;
 
 import java.util.Iterator;
 import java.util.Random;
@@ -22,8 +23,9 @@ public class AzoteMushroomBlock extends MushroomPlantBlock {
     }
 
     @Override
-    public boolean canPathfindThrough(BlockState blockState, BlockView blockView, BlockPos blockPos, NavigationType environment) {
-        BlockState blockBelow = blockView.getBlockState(blockPos.down());
+    public boolean canPlaceAt(BlockState state, WorldView world, BlockPos pos)  {
+        BlockState blockBelow = world.getBlockState(pos.down());
+
         return blockBelow.isIn(UplandsBlockTags.PLANTABLE_ON) ||
                 blockBelow.isIn(TagRegistry.block(new Identifier("luminiferous_uplands:azote_mushroom_spreadable")));
     }
@@ -39,7 +41,7 @@ public class AzoteMushroomBlock extends MushroomPlantBlock {
     }
 
     @Override
-    public void scheduledTick(BlockState blockState, ServerWorld serverWorld, BlockPos blockPos, Random random) {
+    public void randomTick(BlockState blockState, ServerWorld serverWorld, BlockPos blockPos, Random random) {
         // If it should spread this frame
         if (random.nextInt(25) == 0) {
             // The number of mushrooms that can be in close proximity, before it stops spreading.

--- a/src/main/java/robosky/uplands/block/WaterChestnutBlock.java
+++ b/src/main/java/robosky/uplands/block/WaterChestnutBlock.java
@@ -5,9 +5,11 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.CropBlock;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.fluid.Fluids;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
+import robosky.uplands.item.ItemRegistry;
 
 public class WaterChestnutBlock extends CropBlock {
 
@@ -34,5 +36,10 @@ public class WaterChestnutBlock extends CropBlock {
     @Override
     protected boolean canPlantOnTop(BlockState blockState, BlockView blockView, BlockPos blockPos) {
         return blockState.getFluidState().getFluid() == Fluids.WATER;
+    }
+
+    @Override
+    protected ItemConvertible getSeedsItem() {
+        return ItemRegistry.WATER_CHESTNUT_SEEDS_ITEM;
     }
 }

--- a/src/main/java/robosky/uplands/block/ZephyrOnionBlock.java
+++ b/src/main/java/robosky/uplands/block/ZephyrOnionBlock.java
@@ -4,9 +4,11 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.CropBlock;
 import net.minecraft.block.ShapeContext;
+import net.minecraft.item.ItemConvertible;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
+import robosky.uplands.item.ItemRegistry;
 
 public class ZephyrOnionBlock extends CropBlock {
 
@@ -33,5 +35,10 @@ public class ZephyrOnionBlock extends CropBlock {
     @Override
     protected boolean canPlantOnTop(BlockState blockState, BlockView blockView, BlockPos blockPos) {
         return blockState.getBlock() == BlockRegistry.UPLANDER_FARMLAND;
+    }
+
+    @Override
+    protected ItemConvertible getSeedsItem() {
+        return ItemRegistry.ZEPHYR_ONION_ITEM;
     }
 }


### PR DESCRIPTION
- Unawoken Azote Mushrooms can now be placed on dirt-like blocks again (Remapper gave the function the wrong signature for some reason)
- Water Chestnuts and Zephyr Onions now give the correct seed items when pick-block is used on them

That's it for tonight, let me know if there are any other little things like that which could use fixing and I'll try to get to it tomorrow.